### PR TITLE
Fill the lack function

### DIFF
--- a/GonkGPSGeolocationProvider.cpp
+++ b/GonkGPSGeolocationProvider.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "GonkGPSGeolocationProvider.h"
-#include "MozStumbler.h"
+#include "mozstumbler/MozStumbler.h"
 
 #include <pthread.h>
 #include <hardware/gps.h>
@@ -155,7 +155,6 @@ GonkGPSGeolocationProvider::LocationCallback(GpsLocation* location)
 
 
   NS_DispatchToMainThread(new UpdateLocationEvent(somewhere));
-  NS_DispatchToMainThread(new UploadStumbleRunnable());
 
   class RequestCellInfoEvent : public nsRunnable {
   public:

--- a/mozstumbler/MozStumbler.cpp
+++ b/mozstumbler/MozStumbler.cpp
@@ -13,6 +13,10 @@
 
 using namespace mozilla;
 using namespace mozilla::dom;
+
+
+NS_IMPL_ISUPPORTS(StumblerInfo, nsICellInfoListCallback, nsIWifiScanResultsReady)
+
 void
 StumblerInfo::SetWifiInfoResponseReceived()
 {

--- a/mozstumbler/MozStumbler.h
+++ b/mozstumbler/MozStumbler.h
@@ -41,9 +41,5 @@ private:
   int mCellInfoResponsesReceived;
   bool mIsWifiInfoResponseReceived;
 };
-
-NS_IMPL_ISUPPORTS(StumblerInfo, nsICellInfoListCallback, nsIWifiScanResultsReady)
-
-
 #endif // mozilla_system_mozstumbler_h__
 

--- a/mozstumbler/UploadStumbleRunnable.cpp
+++ b/mozstumbler/UploadStumbleRunnable.cpp
@@ -61,6 +61,8 @@ UploadStumbleRunnable::Run()
   rv = target->AddEventListener(NS_LITERAL_STRING("timeout"), listener, false);
   NS_ENSURE_SUCCESS(rv, rv);
   // loadend catches abort, load, and error
+  rv = target->AddEventListener(NS_LITERAL_STRING("load"), listener, false);
+  NS_ENSURE_SUCCESS(rv, rv);
   rv = target->AddEventListener(NS_LITERAL_STRING("loadend"), listener, false);
   NS_ENSURE_SUCCESS(rv, rv);
 
@@ -81,7 +83,6 @@ NS_IMETHODIMP
 UploadEventListener::HandleEvent(nsIDOMEvent* aEvent)
 {
   nsString type;
-
   if (NS_FAILED(aEvent->GetType(type))) {
     STUMBLER_ERR("Failed to get event type");
     WriteStumbleOnThread::UploadEnded(false);


### PR DESCRIPTION
Hi Garvan,
I've done local testing with this patch.

So we will only have stumbles.json.gz or stumbles.done.json.gz at a time.
If stumbles.done.json.gz exists, we won't write a new stumble.

Besides, I found that I still need to add eventListener for "load" or I cannot receive any event.
