### PR TITLE
Add an upload attempt freq guard, uploading attempts are capped at a limit per-day

### DIFF
--- a/mozstumbler/WriteStumbleOnThread.h
+++ b/mozstumbler/WriteStumbleOnThread.h
@@ -40,6 +40,15 @@ private:
   static mozilla::Atomic<bool> sIsUploading;
   // Only run one instance of this
   static mozilla::Atomic<bool> sIsAlreadyRunning;
+
+  // Limit the upload attempts per day. If the device is rebooted
+  // this resets the allowed attempts, which is acceptable.
+  struct UploadFreqGuard {
+    int attempts;
+    int daySinceEpoch;
+  };
+  static UploadFreqGuard sUploadFreqGuard;
+
 };
 
 #endif


### PR DESCRIPTION
@alphan102 r?

This is to prevent hundreds of upload attempts happening if the upload keeps failing. After 20 attempts in a day, just wait until the next day. If the device is rebooted, the upload count is reset, I think that is ok.
